### PR TITLE
updated 0install feeds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:271.0.0
+FROM google/cloud-sdk:292.0.0
 RUN apt-get install -y --no-install-recommends 0install-core unzip jq postgresql-client
 
 # Drop root rights
@@ -8,15 +8,15 @@ WORKDIR /home/user
 ENV PATH="/home/user/bin:${PATH}"
 
 # Setup Helm with helm-autoversion (pre-cache common versions)
-RUN 0install download http://repo.roscidus.com/kubernetes/helm --version 2.14.3
-RUN 0install download http://repo.roscidus.com/kubernetes/helm --version 2.15.2
-RUN 0install download http://repo.roscidus.com/kubernetes/helm --version 2.16.1
-RUN 0install add-feed http://repo.roscidus.com/kubernetes/helm http://repo.roscidus.com/kubernetes/helm-autoversion
-RUN 0install add helm http://repo.roscidus.com/kubernetes/helm --version 2..!3
+RUN 0install download https://apps.0install.net/kubernetes/helm.xml --version 2.14.3
+RUN 0install download https://apps.0install.net/kubernetes/helm.xml --version 2.15.2
+RUN 0install download https://apps.0install.net/kubernetes/helm.xml --version 2.16.1
+RUN 0install add helm https://apps.0install.net/kubernetes/helm.xml --version 2.14..!2.16.2
+RUN 0install add-feed https://apps.0install.net/kubernetes/helm.xml https://apps.0install.net/kubernetes/helm-autoversion.xml
 RUN helm init --client-only
 
 # Install helmfile
-RUN 0install add helmfile http://repo.roscidus.com/kubernetes/helmfile --version-for http://repo.roscidus.com/kubernetes/helm 2..!3
+RUN 0install add helmfile https://apps.0install.net/kubernetes/helmfile.xml --version-for https://apps.0install.net/kubernetes/helm.xml 2.14..!2.16.2
 
 # Install scripts
 COPY *.sh /


### PR DESCRIPTION
1. Updated cloud-sdk image from v271.0.0 to 292.0.0
2. redirected 0install feeds to its new interface
3. Pinned auto-versioning to the highest downloaded helm version. Restricting helm to v2.16.1 as its highest version to avoid a client/server mismatch which we've experienced. 